### PR TITLE
Fix overlapping nodes with indent-parser due to match trimming

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -80,7 +80,11 @@ non-whitespace character of the match."
 (defun origami-indent-parser (create)
   "Not documented, CREATE."
   (cl-labels
-      ((lines (string) (origami-get-positions string ".*?\r?\n"))
+      ((lines (string) (origami-get-positions
+                        string
+                        ".*?\r?\n"
+                        nil
+                        (lambda (match &rest _) (- (point) (length match)))))
        (annotate-levels (lines)
                         (-map (lambda (line)
                                 ;; TODO: support tabs

--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -60,7 +60,8 @@ in the CONTENT.
 Optional argument PREDICATE is for filtering.
 
 Optional argument FNC-POS, is function that returns the mark position
-from the matching string."
+from the matching string. If omitted, the mark will be the first
+non-whitespace character of the match."
   (save-excursion
     (goto-char (point-min))
     (let (acc open)
@@ -72,7 +73,7 @@ from the matching string."
             (setq open (not open))
             (push (cons match
                         (or (ignore-errors (funcall fnc-pos match open))
-                            (- (point) (length (string-trim match)))))
+                            (- (point) (length (string-trim-left match)))))
                   acc))))
       (reverse acc))))
 


### PR DESCRIPTION
#### Description
I encountered an error with indentation folding in a plain text file.

#### Reproduction

- Start Emacs
- Open attached file: [nested_indentation.txt](https://github.com/emacs-origami/origami.el/files/6134786/nested_indentation.txt)
- Enable `origami-mode`
- Call `origami-toggle-node` anywhere

*Observed behaviour:*
Nothing is folded, the following error message is displayed:

`Tried to construct a node where the children overlap or are not distinct regions: ([227 260 12 t ([244 260 16 t nil #<overlay from 260 to 260 in nested_indentation.txt>]) #<overlay from 239 to 260 in nested_indentation.txt>] [257 269 12 t nil #<overlay from 265 to 265 in nested_indentation.txt>])`

*Expected behaviour:*
Nodes get folded.

#### Fix

The `origami-indent-parser` calls `origami-get-positions` with a regex that will match from line beginning to end, including the newline at the end. In `origami-get-positions` the default position correction, when no `fnc-pos` is passed, was to go to the start of the match in Greg's original variant. Now it will move less, by substracting only `(length (string-trim match))`.

The intent behind string-trim is likely to move the start of the node to the first non-whitespace char of the match. I think it should be `string-trim-left` then, in case whitespace also exists at the end of the match, which would move the start too far to the right.

This still not fixes the indent-parser though, as it uses the untrimmed match length for determining the end, and with the changed starting positions things start to overlap. As it makes sense to have the node start at the line beginning here, I just added a fnc-pos that prevents the trimming.