### PR TITLE
Fix build pair tree

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -519,8 +519,8 @@ is the ending point to stop the scanning processs."
              (lambda (pos &rest _) (origami-filter-code-face pos))
              (lambda (match &rest _)
                (if (origami-util-contain-list-type-str end match 'strict)
-                   ;; keep end pos at match start, not line-beginning, to fold leading whitespace
-                   (- (point) (length match))
+                   ;; keep end pos on separate line on folding
+                   (1- (line-beginning-position))
                  (line-beginning-position))))))
       (origami-build-pair-tree create beg-regex end-regex else-regex
                                positions
@@ -653,8 +653,8 @@ See function `origami-python-parser' description for argument CREATE."
              (lambda (pos &rest _) (origami-filter-code-face pos))
              (lambda (match &rest _)
                (if (origami-util-contain-list-type-str end match 'strict)
-                   ;; keep end pos at match start, not line-beginning, to fold leading whitespace
-                   (- (point) (length match))
+                   ;; keep end pos on separate line on folding
+                   (1- (line-beginning-position))
                  (line-beginning-position))))))
       (origami-build-pair-tree create beg-regex end-regex else-regex
                                positions
@@ -690,8 +690,8 @@ See function `origami-python-parser' description for argument CREATE."
              (lambda (pos &rest _) (origami-filter-code-face pos))
              (lambda (match &rest _)
                (if (origami-util-contain-list-type-str end match 'strict)
-                   ;; keep end pos at match start, not line-beginning, to fold leading whitespace
-                   (- (point) (length match))
+                   ;; keep end pos on separate line on folding
+                   (1- (line-beginning-position))
                  (line-beginning-position))))))
       (origami-build-pair-tree create beg-regex end-regex else-regex
                                positions

--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -153,76 +153,95 @@ non-whitespace character of the match."
           cdr))))
 
 (defun origami-build-pair-tree (create open close else positions &optional fnc-offset)
-  "Build the pair tree from CREATE.
+  "Build the node tree from POSITIONS.
 
-Argument OPEN and CLOSE is the open/close symbol in type of string.
+Argument CREATE is the parser function to create the nodes.
 
-Argument POSITIONS is a list of cons cell form by (syntax . point).
+Arguments OPEN, CLOSE and ELSE are regular expressions used to
+determine the type of a position. An OPEN match will start a new
+pending node, a CLOSE match will finish a started pending node,
+an ELSE match works like CLOSE + OPEN - it will finish a started
+pending node, then immediately start a new one.
+
+Argument POSITIONS is a list of cons cell form by (match . point).
 
 Optional argument FNC-OFFSET is a function that return's the position of
-the offset."
-  (let (ml-open)
-    (cl-labels
-        ((build (positions)
-                ;; this is so horrible, but fast
-                (let ((should-continue t) acc beg
-                      match match-open match-close match-else)
-                  (while (and should-continue positions)
-                    (setq match (caar positions))
-                    (origami-log "\f")
-                    (origami-log "current match: %s" match)
-                    (origami-log "beg: %s" beg)
-                    (cond
+the node offset."
+  (cl-labels
+      ((build (positions)
+              ;; recursive function to build nodes from positions, returns cons cell with
+              ;; (remaining-positions . created-nodes)
+              (let ((tree-level-unfinished t) ; nil indicates the current tree level was finished by
+                                              ; a closing match, and we need to ascend back to upper
+                                              ; level from recursion
+                    acc ; accumulates created nodes
+                    beg-pos ; beginning pos of started, but unfinished (not created) node
+                    beg-match ; beginning match of started, but unfinished node
+                    cur-pos ; pos of current position
+                    cur-match)
+                (while (and tree-level-unfinished positions)
+                  (setq cur-match (caar positions)
+                        cur-pos (cdar positions))
+                  (origami-log "\f")
+                  (origami-log "current match: %s" cur-match)
+                  (origami-log "beg (pos, cur-match): %s, %s" beg-pos beg-match)
+                  (cond
                      ;;; --- ELSE --------------------------------------------
-                     ((and (stringp else) (string-match-p else match))
-                      (origami-log ">> else: " match)
-                      ;; Close without changing parent node.
-                      (setq match-else (nth 0 ml-open))
-                      (push (funcall create beg (cdar positions)
-                                     (or (origami-util-function-offset fnc-offset beg match)
-                                         (length match-else))
-                                     nil)
-                            acc)
-                      ;; Stays the same, doesn't go up/down a level.
-                      (setq beg (1+ (cdar positions))
-                            positions (cdr positions)))
+                   ((and (stringp else) (string-match-p else cur-match))
+                    (origami-log ">> else: " cur-match)
+                    ;; Stay on same level - finish beg node & start new one. As we are starting a
+                    ;; new node at cur-pos, make the beg node end at one char before that.
+                    (push (funcall create beg-pos (1- cur-pos)
+                                   (or (origami-util-function-offset fnc-offset beg-pos beg-match)
+                                       (length beg-match))
+                                   nil)
+                          acc)
+                    ;; begin a new pair
+                    (setq beg-pos cur-pos
+                          beg-match cur-match
+                          positions (cdr positions)))
                      ;;; --- OPEN --------------------------------------------
-                     ((string-match-p open match)
-                      (origami-log ">> open: " match)
-                      (setq match-open match)
-                      (push match-open ml-open)
-                      (if beg  ; go down a level
-                          (progn
-                            (origami-log "dig in...")
-                            (pop ml-open)
-                            (let* ((res (build positions))
-                                   (new-pos (car res)) (children (cdr res)))
-                              (setq positions (cdr new-pos))
-                              (push (funcall create beg (cdar new-pos)
-                                             (or (origami-util-function-offset fnc-offset beg match-open)
-                                                 (length (nth 0 ml-open)))
-                                             children)
-                                    acc)
-                              (setq beg nil)))
-                        ;; begin a new pair
-                        (setq beg (cdar positions)
-                              positions (cdr positions))))
-                     ;;; --- CLOSE --------------------------------------------
-                     ((string-match-p close match)
-                      (origami-log ">> close: " match)
-                      (if beg  ; close with no children
-                          (progn
-                            (setq match-close (pop ml-open))
-                            (push (funcall create beg (cdar positions)
-                                           (or (origami-util-function-offset fnc-offset beg match-close)
-                                               (length match-close))
-                                           nil)
+                   ((string-match-p open cur-match)
+                    (origami-log ">> open: " cur-match)
+                    (if beg-pos  ; go down a level
+                        (progn
+                          (origami-log "dig in...")
+                          (let* ((res (build positions)) ; recurse
+                                 (new-pos (car res))
+                                 (children (cdr res))
+                                 (close-pos (cdar new-pos)))
+                            ;; close with children
+                            (push (funcall create beg-pos close-pos
+                                           (or (origami-util-function-offset fnc-offset beg-pos beg-match)
+                                               (length beg-match))
+                                           children)
                                   acc)
-                            (setq positions (cdr positions)
-                                  beg nil))
-                        (setq should-continue nil)))))
-                  (cons positions (reverse acc)))))
-      (cdr (build positions)))))
+                            (setq beg-pos nil
+                                  beg-match nil
+                                  positions (cdr new-pos))))
+                      ;; begin a new pair
+                      (setq beg-pos cur-pos
+                            beg-match cur-match
+                            positions (cdr positions))))
+                     ;;; --- CLOSE --------------------------------------------
+                   ((string-match-p close cur-match)
+                    (origami-log ">> close: " cur-match)
+                    (if beg-pos  ; close with no children
+                        (progn
+                          (push (funcall create beg-pos cur-pos
+                                         (or (origami-util-function-offset fnc-offset beg-pos beg-match)
+                                             (length beg-match))
+                                         nil)
+                                acc)
+                          (setq beg-pos nil
+                                beg-match nil
+                                positions (cdr positions)))
+                      ;; stop loop to reascend to upper tree level
+                      (setq tree-level-unfinished nil)))))
+                (origami-log "dig out...")
+                ;; Pass remaining positions and accumulated nodes up the recursion stack
+                (cons positions (reverse acc)))))
+    (cdr (build positions))))
 
 (defun origami--force-pair-positions (positions)
   "Force POSITIONS pair into a length of even number."
@@ -501,8 +520,9 @@ is the ending point to stop the scanning processs."
              content all-regex
              (lambda (pos &rest _) (origami-filter-code-face pos))
              (lambda (match &rest _)
-               (if (origami-util-contain-list-type-str (append end else) match 'regex)
-                   (1- (line-beginning-position))
+               (if (origami-util-contain-list-type-str end match 'strict)
+                   ;; keep end pos at match start, not line-beginning, to fold leading whitespace
+                   (- (point) (length match))
                  (line-beginning-position))))))
       (origami-build-pair-tree create beg-regex end-regex else-regex
                                positions
@@ -634,10 +654,10 @@ See function `origami-python-parser' description for argument CREATE."
              content all-regex
              (lambda (pos &rest _) (origami-filter-code-face pos))
              (lambda (match &rest _)
-               (cond ((origami-util-contain-list-type-str beg match 'strict)
-                      (line-beginning-position))
-                     ((origami-util-contain-list-type-str (append end else) match 'strict)
-                      (1- (line-beginning-position))))))))
+               (if (origami-util-contain-list-type-str end match 'strict)
+                   ;; keep end pos at match start, not line-beginning, to fold leading whitespace
+                   (- (point) (length match))
+                 (line-beginning-position))))))
       (origami-build-pair-tree create beg-regex end-regex else-regex
                                positions
                                (lambda (match &rest _)
@@ -671,10 +691,10 @@ See function `origami-python-parser' description for argument CREATE."
              content all-regex
              (lambda (pos &rest _) (origami-filter-code-face pos))
              (lambda (match &rest _)
-               (cond ((origami-util-contain-list-type-str beg match 'strict)
-                      (line-beginning-position))
-                     ((origami-util-contain-list-type-str (append end else) match 'strict)
-                      (1- (line-beginning-position))))))))
+               (if (origami-util-contain-list-type-str end match 'strict)
+                   ;; keep end pos at match start, not line-beginning, to fold leading whitespace
+                   (- (point) (length match))
+                 (line-beginning-position))))))
       (origami-build-pair-tree create beg-regex end-regex else-regex
                                positions
                                (lambda (&rest _) (line-end-position))))))

--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -518,7 +518,7 @@ is the ending point to stop the scanning processs."
              content all-regex
              (lambda (pos &rest _) (origami-filter-code-face pos))
              (lambda (match &rest _)
-               (if (origami-util-contain-list-type-str end match 'strict)
+               (if (origami-util-contain-list-type-str end match 'regex)
                    ;; keep end pos on separate line on folding
                    (1- (line-beginning-position))
                  (line-beginning-position))))))

--- a/origami.el
+++ b/origami.el
@@ -620,6 +620,7 @@ with the current state and the current node at each iteration."
                                       (buffer-local-value 'major-mode buffer))
                                     origami-parser-alist))
                         'origami-indent-parser))
+      (origami-log "Selected parser %s" parser-gen)
       (funcall parser-gen create))))
 
 (defun origami-get-fold-tree (buffer)

--- a/origami.el
+++ b/origami.el
@@ -682,24 +682,23 @@ The fold node opened will be the deepest nested at POINT."
 
 ;;;###autoload
 (defun origami-open-node-recursively-till-depth (buffer point depth &optional include-siblings)
-  "Opens childs from the node at point up to the given depth, and collapses all other.
+  "Opens childs from the node at POINT up to the given DEPTH, and collapses all other.
 
-`depth' is relative to the node at point. It can be passed
+DEPTH is relative to the node at point. It can be passed
 interactively as a numeric prefix argument.
 
-`include-siblings' will also open the siblings of the node at
+INCLUDE-SIBLINGS will also open the siblings of the node at
 point up to the given depth. This can be useful if there is no
 single root in the document folding structure. To set it
 interactively, use a negative prefix arg."
   (interactive (let* ((numeric-prefix-arg (prefix-numeric-value current-prefix-arg))
-                      (include-siblings (< numeric-prefix-arg 0))
-                      (depth (if include-siblings
-                                 ;; need to start one level further up, keep depth relative to node
-                                 ;; at point
-                                 (1+ (abs numeric-prefix-arg))
-                               numeric-prefix-arg)))
-                 (list (current-buffer) (point) depth include-siblings)))
+                      (include-siblings (< numeric-prefix-arg 0)))
+                 (list (current-buffer) (point) (abs numeric-prefix-arg) include-siblings)))
   (-when-let (old-tree (origami-get-fold-tree buffer))
+    ;; need to start one level further up, keep depth relative to node
+    ;; at point
+    (when include-siblings
+      (setq depth (1+ depth)))
     (cl-labels ((open-node (node) (origami-fold-open-set node t))
                 (close-node (node) (origami-fold-open-set node nil))
                 (open-recursively-till-depth (current-node current-depth)


### PR DESCRIPTION
### Description

I am writing an xml parser, but encountered 2 problems with `origami-build-pair-tree` along the
way. This PR contains fixes for these (new parser will be a separate PR later), plus comments and
cosmetic changes that I hope will make reading the code easier, as I had some trouble understanding
what was going on :) Hope I got everything right, and you find this useful...

I also bundled a commit with a minor fix for non-interactive calls of the
`origami-open-node-recursively-till-depth`, sorry.

### Bug 1 - `origami-build-pair-tree` - wrong open match passed to fnc-offset

If the `build` function creates a node with children ("dig in" form, after coming back from
recursion), it passes the wrong match to fnc-offset. Instead of the opening match that started that
node in a prior loop, the current opening match is passed, but that belongs to the first child
(which triggered the recursion).

The fallback logic, if no fnc-offset is passed, uses ml-open, but this also contains the wrong
value.

#### Reproduction

Any parser that would evaluate the match length might produce errors, if the parent and child opening
tag differ.

With the existing parsers I cannot produce an error, because they don't evaluate it. The ruby parser
e.g. will always set its offset to the end of the line.

I could provide my xml parser early with a parsing sample for reproduction, if you like.

#### Fix

I refactored a bit, basically I keep the opening match in a variable now, just like it already works
for the opening pos in `beg`. I named them `beg-pos` and `beg-match`, and the current node variables
`cur-pos` and `cur-match`, and use these matches to pass to fnc-offset.

I removed ml-open and several match variables, as it seemed no longer necessary.

### Bug 2 - `origami-build-pair-tree` - "else" match node starts one char after match position

To my understanding, else will end a previously started node, and start a new one with the "else"
match as the new start. It adds +1 to `beg` though, making it start one char to the right of the
else position.

#### Reproduction

Again no error producable with the current parsers, as they correct for that by offset function.
E.g. the ruby parser will do so by passing a `fnc-pos` to `origami-get-positions`, that for ending
and else positions will use `line-beginning-position` - 1, so that these nodes starting pos will be
the end of the previous line.

#### Fix

Don't add +1 to the new opening pos, instead make the previous node end one char before our else
match.

Then I could remove the "hacks" in the parsers fnc-pos that altered the else/end position by -1:

-   origami-ruby-core-parser
-   origami-c-macro-parser
-   origami-lua-core-parser

I changed the positions of the end nodes to the first non-whitespace in the line instead, so
whitespace before a nested end will be folded too. Otherwise it is considered part of the parent
node, and would stay visible.

Ruby sample:
```
    if x > 1
      if x > 2
        puts "x is greater than 2"
      end
    end
```
