### PR TITLE
Add json parser, fix markers parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ To some degree, yes. Currently out of the box support is provided for:
 * Go
 * HTML
 * Java / JavaScript / JSX
+* JSON
 * Kotlin
 * Lisp / Lua
 * Markdown


### PR DESCRIPTION
This adds a very simple json parser (fold objects and arrays), and fixes a small issue:

origami-markers-parser matched markers literally for get-positions, and as regex in build-pair-tree. I added an argument to specify if regex or literal match is wanted.