### PR TITLE
Auto-close unclosed folds in build-pair-tree

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -205,7 +205,8 @@ the node offset."
                           (let* ((res (build positions)) ; recurse
                                  (new-pos (car res))
                                  (children (cdr res))
-                                 (close-pos (cdar new-pos))
+                                 ;; auto-close unclosed folds at point-max
+                                 (close-pos (or (cdar new-pos) (point-max)))
                                  (node (funcall create beg-pos close-pos
                                                 (or (origami-util-function-offset fnc-offset beg-pos beg-match)
                                                     (length beg-match))


### PR DESCRIPTION
Otherwise close-pos is nil and passed to the create function, where it will trigger an error further down, and the tree construction fails.

Sample xml for repro:
```
<unclosed>
<a>
</a>
```